### PR TITLE
Monthly Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: monthly


### PR DESCRIPTION
It should be sufficient to update dependencies once a month. There is no need for daily updates.