### PR TITLE
Update Test Systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,12 +42,12 @@ jobs:
             version: '9'
           - dist: centos
             version: 9-Stream
-          - dist: fedora
-            version: '37'
           - dist: rockylinux
             version: '9'
           - dist: debian
             version: bullseye
+          - dist: debian
+            version: bookworm
           - dist: ubuntu
             version: jammy
     steps:


### PR DESCRIPTION
This patch updates list of distributions used for testing:

- Remove old, unsupported Fedora version
- Do not include new Fedora (we don't want to update this all the time)
- Add latest version of Debian