### PR TITLE
Test all branches except Dependabot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,9 @@
 name: 'build-test'
-on: # rebuild any PRs and main branch changes
+on:
   pull_request:
   push:
-    branches:
-      - main
-      - releases/*
+    branches-ignore:
+      - 'dependabot/**'
 
 jobs:
   build: # make sure build/ci work properly


### PR DESCRIPTION
This patch changes when tests are run by including all branches except those created by Dependabot since they always create a pull request anyway.