### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 16.x
 
       - run: |
-          npm install
+          npm ci
 
       - run: |
           npm run build


### PR DESCRIPTION
This patch switches to `npm ci` in the tests since we want reproducible builds (exactly the dependencies we specified).