### PR TITLE
Update to Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   ip:
     description: IP address of the container that was set up.
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
The action still used the deprecated Node.js 16. This patch switches to the current LTS (Node.js 30) instead.