### PR TITLE
Fix ESLint dependency group name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     schedule:
       interval: monthly
     groups:
-      fontawesome:
+      eslint:
         patterns:
           - "*eslint*"


### PR DESCRIPTION
Renamed the 'fontawesome' group to 'eslint'