### PR TITLE
Align Node runtime to node24 across action, CI, and @types/node

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set-up Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: use node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - run: |
           npm ci

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   ip:
     description: IP address of the container that was set up.
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.0",
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.13.3",
         "@typescript-eslint/eslint-plugin": "^8.48.0",
         "@typescript-eslint/parser": "^8.32.1",
         "@vercel/ncc": "^0.44.1",
@@ -24,6 +24,9 @@
         "eslint-plugin-prettier": "^5.5.4",
         "prettier": "3.8.3",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {
@@ -417,13 +420,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3652,9 +3655,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,12 +23,15 @@
   ],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "@actions/core": "^1.11.1"
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.13.3",
     "@typescript-eslint/eslint-plugin": "^8.48.0",
     "@typescript-eslint/parser": "^8.32.1",
     "@vercel/ncc": "^0.44.1",


### PR DESCRIPTION
action.yml declared node20 and CI used node-version 20.x while @types/node was already at ^25.6.0, three majors ahead of the declared runtime. Bump the actual runtime to node24 (now supported by GitHub Actions) and set @types/node to ^24.13.3 to match, plus add an explicit engines.node field since none existed.