### PR TITLE
Remove stale dependabot eslint group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    groups:
-      eslint:
-        patterns:
-          - "*eslint*"


### PR DESCRIPTION
We removed every ESLint/Prettier-related dependency in favor of Biome, leaving this *eslint* pattern group matching nothing.