### PR TITLE
Update tested/documented OS versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,21 +38,23 @@ jobs:
       matrix:
         distribution:
           - dist: almalinux
+            version: '9'
+          - dist: almalinux
             version: '10'
           - dist: centos
             version: 10-Stream
+          - dist: fedora
+            version: '44'
           - dist: rockylinux
             version: '9'
           - dist: rockylinux
             version: '10'
           - dist: debian
-            version: bookworm
-          - dist: debian
             version: trixie
           - dist: ubuntu
-            version: jammy
-          - dist: ubuntu
             version: noble
+          - dist: ubuntu
+            version: resolute
     steps:
       - uses: actions/checkout@v7
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ For example, this is a great way to test Ansible roles or playbooks.
     dist: centos
 
     # Distribution release to use
-    # Default: 9-Stream
-    release: 9-Stream
+    # Default: 10-Stream
+    release: 10-Stream
 
     # LXC container name.
     # Will also be used as hostname in /etc/hosts if configure-etc-hosts is set.

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   release:
     required: true
     description: Distribution release
-    default: 9-Stream
+    default: 10-Stream
   name:
     required: true
     description: Container name


### PR DESCRIPTION
Debian bookworm hit its official EOL on 2026-07-11, so drop it from the test matrix in favor of trixie (supported until 2028) as the sole Debian target. Add Ubuntu 26.04 LTS "Resolute Raccoon" (the current latest LTS, released ~April 2026) and drop the aging jammy (22.04), leaving noble + 26.04 as the two current LTS releases.

Add Fedora 44 to the test matrix: README documents Fedora as supporting automatic SSH/Python setup, but it previously had zero test coverage. Add AlmaLinux 9 alongside the existing 10 for parity with Rocky Linux's dual-major coverage.

Bump the documented default release from CentOS 9-Stream to 10-Stream in both action.yml and README.md, aligning the default with what the test matrix actually exercises. This is a behavior change for consumers relying on the implicit default, not just a docs fix -- centos with no explicit release now provisions 10-Stream instead of 9-Stream.