### PR TITLE
Bump actions/setup-node to major-only v7 pin

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set-up Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: use node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
 


### PR DESCRIPTION
actions/checkout, actions/upload-artifact, and github/codeql-action/* are already pinned to major-only tags (v7, v7, v4) which auto-track patch/minor releases. actions/setup-node was the outlier, pinned to the exact v6.4.0 and also a full major behind (v7.0.0 is out, no breaking changes relevant to our plain node-version usage). Align it to the same major-only convention.